### PR TITLE
fix a strict PHP error

### DIFF
--- a/Lib/CakeRavenClient.php
+++ b/Lib/CakeRavenClient.php
@@ -3,7 +3,7 @@
 App::uses('ClassRegistry', 'Utility');
 
 class CakeRavenClient extends Raven_Client {
-    public function capture($data, $stack) {
+    public function capture($data, $stack, $vars = NULL) {
     	if (class_exists('AuthComponent')) {
     		$model= Configure::read('Sentry.User.model');
     		if (empty($model)) $model = 'User';


### PR DESCRIPTION
Declaration of CakeRavenClient::capture() should be compatible with Raven_Client::capture($data, $stack, $vars = NULL) [APP/Plugin/Sentry/Lib/CakeRavenClient.php, line 5]
