### PR TITLE
Add SentryConsoleErrorHandler for handling Console Errors

### DIFF
--- a/Lib/SentryConsoleErrorHandler.php
+++ b/Lib/SentryConsoleErrorHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+
+App::import('Vendor', 'Sentry.Raven/lib/Raven/Autoloader');
+App::uses('ConsoleErrorHandler', 'Console');
+/**
+ * Description of SentryConsoleErrorHandler
+ *
+ * @author Sandreu
+ */
+class SentryConsoleErrorHandler extends ConsoleErrorHandler {
+
+	protected static function sentryLog(Exception $exception) {
+		if (Configure::read('debug')==0 || !Configure::read('Sentry.production_only')) {
+			Raven_Autoloader::register();
+			App::uses('CakeRavenClient', 'Sentry.Lib');
+
+			$client = new CakeRavenClient(Configure::read('Sentry.PHP.server'));
+			$client->captureException($exception, get_class($exception), 'PHP');
+		}
+	}
+
+	public function handleException(Exception $exception) {
+		try {
+			// Avoid bot scan errors
+			if (($exception instanceof MissingControllerException || $exception instanceof MissingPluginException) && Configure::read('debug')==0) {
+				echo 'Cette url n\'est pas valide.';
+				exit(0);
+			}
+
+			self::sentryLog($exception);
+
+			return parent::handleException($exception);
+		} catch (Exception $e) {
+			return parent::handleException($e);
+		}
+	}
+
+	public function handleError($code, $description, $file = null, $line = null, $context = null) {
+		try {
+			$e = new ErrorException($description, 0, $code, $file, $line);
+			self::sentryLog($e);
+
+			return parent::handleError($code, $description, $file, $line, $context);
+		} catch (Exception $e) {
+			self::handleException($e);
+		}
+	}
+}


### PR DESCRIPTION
In relation to https://github.com/Sandreu/cake-sentry/issues/4.

The following code needs to be placed in "bootstrap.php", right after the CakePlugin('Sentry') has been loaded.

``` php
  App::uses('SentryConsoleErrorHandler', 'Sentry.Lib');

  Configure::write('Error', array(
    'handler' => 'SentryErrorHandler::handleError',
    'consoleHandler' => [new SentryConsoleErrorHandler(), 'handleError'],
    'level' => E_ALL & ~E_DEPRECATED,
    'trace' => true
  ));

  Configure::write('Exception', array(
    'handler' => 'SentryErrorHandler::handleException',
    'consoleHandler' => [new SentryConsoleErrorHandler(), 'handleException'],
    'renderer' => 'ExceptionRenderer',
    'log' => true
  ));
```
