### PR TITLE
Fix directory name when installed via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "type": "cakephp-plugin",
     "description": "Sentry error handler plugin for CakePHP2",
     "keywords": ["Sentry", "CakePHP", "Log", "Error", "Exception"],
+    "extra": {
+        "installer-name": "Sentry"
+    },
     "require": {
         "php": ">=5.2.8",
         "raven/raven": "~0.10",


### PR DESCRIPTION
Currently installing through Composer will place the plugin in to a directory named CakeSentry. This breaks the plugin, as it expects to be in a directory named Sentry.