### PR TITLE
CakePHP 2.8/PHP7 compatibility

### DIFF
--- a/Lib/SentryConsoleErrorHandler.php
+++ b/Lib/SentryConsoleErrorHandler.php
@@ -9,7 +9,7 @@ App::uses('ConsoleErrorHandler', 'Console');
  */
 class SentryConsoleErrorHandler extends ConsoleErrorHandler {
 
-	protected static function sentryLog(Exception $exception) {
+	protected static function sentryLog($exception) {
 		if (Configure::read('debug')==0 || !Configure::read('Sentry.production_only')) {
 			Raven_Autoloader::register();
 			App::uses('CakeRavenClient', 'Sentry.Lib');
@@ -19,7 +19,7 @@ class SentryConsoleErrorHandler extends ConsoleErrorHandler {
 		}
 	}
 
-	public function handleException(Exception $exception) {
+	public function handleException($exception) {
 		try {
 			// Avoid bot scan errors
 			if (Configure::read('Sentry.avoid_bot_scan_errors') && ($exception instanceof MissingControllerException || $exception instanceof MissingPluginException) && Configure::read('debug')==0) {

--- a/Lib/SentryErrorHandler.php
+++ b/Lib/SentryErrorHandler.php
@@ -8,7 +8,7 @@
  */
 class SentryErrorHandler extends ErrorHandler {
 
-    protected static function sentryLog(Exception $exception) {
+    protected static function sentryLog($exception) {
         if (Configure::read('debug')==0 || !Configure::read('Sentry.production_only')) {
             Raven_Autoloader::register();
             App::uses('CakeRavenClient', 'Sentry.Lib');
@@ -18,7 +18,7 @@ class SentryErrorHandler extends ErrorHandler {
         }
     }
 
-    public static function handleException(Exception $exception) {
+    public static function handleException($exception) {
         try {
             // Avoid bot scan errors
             if (Configure::read('Sentry.avoid_bot_scan_errors') && ($exception instanceof MissingControllerException || $exception instanceof MissingPluginException) && Configure::read('debug')==0) {

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Cake-Sentry
 
 **Cake-Sentry** is an error handler plugged on [Sentry](http://www.getsentry.com) - [docs](http://sentry.readthedocs.org/en/latest/quickstart/index.html#setting-up-an-environment)
 
+Compatibility
+=============
+This library is only compatible with CakePHP >= 2.8 and < 3.0. If you need support for CakePHP < 2.8 please use the 0.1.0 release of cake-sentry.
+
 Installation
 ------------
 **Note if you don't install from composer you will have to manually download the raven component and install it before proceeding to step 2.**

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sandreu/cake-sentry",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "type": "cakephp-plugin",
     "description": "Sentry error handler plugin for CakePHP2",
     "keywords": ["Sentry", "CakePHP", "Log", "Error", "Exception"],


### PR DESCRIPTION
The signature of `\ErrorHandler::handleException` and `\ConsoleErrorHandler::handleException` changed in CakePHP 2.8. They **do not** contain the `Exception` type hint anymore for PHP7 compatibility.

This PR matches the signature as of CakePHP 2.8!

In PHP7 a function for receiving uncaught exception via `set_exception_handler()` may now receive anything which is of the interface `Throwable` as the hierarchy has changed (`Exception implements Throwable` now and a new `Error implements Throwable` has been implemented).

I've tested this code to work with `Exception` and `Error` and in PHP5 as well as PHP7.

**Drawback:** this effectively makes this library **incomaptible** with CakePHP < 2.8 !

My suggestion is:
- tag the *current* master with a 0.1.0 release ensure it is published to packagist [1]
- merge this PR and tag a 0.2.0 and publish is on packagist too.

This way, people wanting this for CakePHP < 2.8 still can get it properly via composer. This suggestion is already reflected in the `README.md` and the `composer.json`.

[1] https://packagist.org/packages/sandreu/cake-sentry