### PR TITLE
Fix compatibility with sentry 1.10.1

### DIFF
--- a/Lib/SentryConsoleErrorHandler.php
+++ b/Lib/SentryConsoleErrorHandler.php
@@ -15,7 +15,7 @@ class SentryConsoleErrorHandler extends ConsoleErrorHandler {
 			App::uses('CakeRavenClient', 'Sentry.Lib');
 
 			$client = new CakeRavenClient(Configure::read('Sentry.PHP.server'));
-			$client->captureException($exception, get_class($exception), 'PHP');
+			$client->captureException($exception, ['extra' => ['php_version' => PHP_VERSION, 'class' => get_class($exception)]]);
 		}
 	}
 


### PR DESCRIPTION
https://github.com/Sandreu/cake-sentry/pull/17 added support for newer sentry but only adapted `SentryErrorHandler` and not `SentryConsoleErrorHandler`.

It's a small change only, it's just the calling semantics for `captureException` and they second parameter is expected to be an array, not the name of the exception class.

I used the same values (`php_version`, `class`) as the original PR.