### PR TITLE
Remove writing data to the session from the error handler

### DIFF
--- a/Lib/SentryErrorHandler.php
+++ b/Lib/SentryErrorHandler.php
@@ -39,14 +39,12 @@
                         "email" => AuthComponent::user($mail)
                     ));
                 }
-                $eventId = $client->captureException($exception, array(
+                $client->captureException($exception, array(
                     'extra' => array(
                         'php_version' => phpversion(),
                         'class' => get_class($exception)
                     ),
                 ));
-
-                CakeSession::write('sentry_event_id',$eventId);
             }
         }
 


### PR DESCRIPTION
See https://github.com/Sandreu/cake-sentry/pull/17/files#r236091831 for the reasons, TL;DR:
> This seems highly application specific to me and shouldn't be here in the first place. Or at least, be disabled by default.

As I don't know the reason for this in the first place, IMHO for existing users of this library it's better to remove this (writing something to the CakeSession was never there in the first place).