### PR TITLE
Fix error Class Raven_Autoloader not found

### DIFF
--- a/Lib/SentryErrorHandler.php
+++ b/Lib/SentryErrorHandler.php
@@ -1,5 +1,6 @@
 <?php
 
+    App::import('Vendor', 'Autoloader', array('file' => 'raven' . DS . 'raven' . DS . 'lib' . DS . 'Raven' . DS . 'Autoloader.php'));
 
     /**
      * Description of SentryErrorHandler


### PR DESCRIPTION
Bugfix Class Raven_Autoloader not found in the SentryErrorHandler class.
Without this bugfix, I can't use cake-sentry plugin.